### PR TITLE
pdf: normalize customer address top margin

### DIFF
--- a/InvoiceGenerator/pdf.py
+++ b/InvoiceGenerator/pdf.py
@@ -154,7 +154,7 @@ class SimpleInvoice(BaseInvoice):
         self.pdf.drawString(LEFT * mm, TOP * mm, _(u'Customer'))
         self.pdf.setFont('DejaVu', 8)
 
-        text = self.pdf.beginText((LEFT + 2) * mm, (TOP - 4) * mm)
+        text = self.pdf.beginText((LEFT + 2) * mm, (TOP - 6) * mm)
         text.textLines(self.invoice.client.get_address_lines())
         self.pdf.drawText(text)
 


### PR DESCRIPTION
The space between 'Customer' title and its address (4 mm) was not
consistent) with the one used for the Provider (6 mm).  Make them the
same (6 mm).
