### PR TITLE
Add 'test' to setup.py + update README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ InvoiceGenerator
 
 This is library to generate a simple PDF invoice. It's based on ReportLab.
 
-Instalation
-===========
+Installation
+============
 
 Run this command as root::
 
@@ -46,3 +46,13 @@ Usage::
 	pdf = SimpleInvoice(invoice)
 	pdf.gen(tmp_file.name, generate_qr_code=True)
 
+Hacking
+=======
+
+Fork the [repository on github](https://github.com/creckx/InvoiceGenerator) and
+write code. Make sure to add tests covering your code under `/tests/`. You can
+run tests using::
+
+    python setup.py test
+
+Then propose your patch via a pull request.

--- a/setup.py
+++ b/setup.py
@@ -50,4 +50,5 @@ setup(
         "reportlab", "pillow", "qrplatba>=0.3.3"
     ],
     package_data={'InvoiceGenerator': ['locale/*/LC_MESSAGES/*']},
+    test_suite='tests',
 )


### PR DESCRIPTION
I noticed the `bin/run_tests.sh` command line, but it is much easier for
me to just use the convention: python setup.py test

Add to setup() the test_suite=tests to register a test command
Add to README.md an "Hacking section" referencing the reference github
repository and explaining how to run the test suite.
