### PR TITLE
Add support for 2 line addresses

### DIFF
--- a/InvoiceGenerator/api.py
+++ b/InvoiceGenerator/api.py
@@ -16,15 +16,16 @@ class UnicodeProperty(object):
 
 
 class Address(UnicodeProperty):
-    _attrs = ('summary', 'address', 'city', 'zip', 'phone', 'email',
+    _attrs = ('summary', 'address', 'address2', 'city', 'zip', 'phone', 'email',
               'bank_name', 'bank_account', 'note', 'vat_id', 'ir',
               'logo_filename')
 
-    def __init__(self, summary, address='', city='', zip='', phone='', email='',
+    def __init__(self, summary, address='', address2='', city='', zip='', phone='', email='',
                bank_name='', bank_account='', note='', vat_id='', ir='',
                logo_filename='', vat_note=''):
         self.summary = summary
         self.address = address
+        self.address2 = address2
         self.city = city
         self.zip = zip
         self.phone = phone
@@ -38,11 +39,21 @@ class Address(UnicodeProperty):
         self.logo_filename = logo_filename
 
     def get_address_lines(self):
-        address_line = [
-            self.summary,
-            self.address,
-            u'%s %s' % (self.zip, self.city)
-            ]
+        address_line = []
+
+        if self.address2 is '':
+            address_line = [
+                self.summary,
+                self.address,
+                u'%s %s' % (self.zip, self.city)
+                ]
+        else:
+            address_line = [
+                self.summary,
+                self.address,
+                self.address2,
+                u'%s %s' % (self.zip, self.city)
+                ]
         if self.vat_id:
             address_line.append(_(u'Vat in: %s') % self.vat_id)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from InvoiceGenerator.api import Client, Provider, Address, Creator, Item, \
 
 class AddressTest(unittest.TestCase):
 
-    attrs = ('summary', 'address', 'city', 'zip', 'phone', 'email',
+    attrs = ('summary', 'address', 'address2', 'city', 'zip', 'phone', 'email',
              'bank_name', 'bank_account', 'note', 'vat_id', 'ir')
 
     addresss_object = Address
@@ -29,12 +29,18 @@ class AddressTest(unittest.TestCase):
     def test_get_address_lines(self):
         summary = 'Py s.r.o.'
         address = 'Prague street'
+        address2 = 'Building 123'
         zip_code = '1344234234'
         city = 'Prague'
 
-        address_object = self.addresss_object(summary, address, city, zip_code)
+        address_object = self.addresss_object(summary=summary, address=address, city=city, zip_code=zip_code)
 
         expected = [summary, address, u'%s %s' % (zip_code, city)]
+        self.assertEquals(expected, address_object.get_address_lines())
+
+        address_object = self.addresss_object(summary=summary, address=address, address2=address2, city=city, zip_code=zip_code)
+
+        expected = [summary, address, address2, u'%s %s' % (zip_code, city)]
         self.assertEquals(expected, address_object.get_address_lines())
 
     def test_get_contact_lines(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,12 +33,12 @@ class AddressTest(unittest.TestCase):
         zip_code = '1344234234'
         city = 'Prague'
 
-        address_object = self.addresss_object(summary=summary, address=address, city=city, zip_code=zip_code)
+        address_object = self.addresss_object(summary=summary, address=address, city=city, zip=zip_code)
 
         expected = [summary, address, u'%s %s' % (zip_code, city)]
         self.assertEquals(expected, address_object.get_address_lines())
 
-        address_object = self.addresss_object(summary=summary, address=address, address2=address2, city=city, zip_code=zip_code)
+        address_object = self.addresss_object(summary=summary, address=address, address2=address2, city=city, zip=zip_code)
 
         expected = [summary, address, address2, u'%s %s' % (zip_code, city)]
         self.assertEquals(expected, address_object.get_address_lines())


### PR DESCRIPTION
In many cases you will needed to represent an address with 2 lines. Commonly this is used for specific buildings, offices, or apartments.