### PR TITLE
Fix deprecation warnings: .format() -> .format_string(), .assertEqual…

### DIFF
--- a/InvoiceGenerator/pdf.py
+++ b/InvoiceGenerator/pdf.py
@@ -361,9 +361,9 @@ class SimpleInvoice(BaseInvoice):
             i -= 4.23
             if items_are_with_tax:
                 if float(int(item.count)) == item.count:
-                    self.pdf.drawRightString((LEFT + 85) * mm, (TOP - i) * mm, u'%s %s' % (locale.format("%i", item.count, grouping=True), item.unit))
+                    self.pdf.drawRightString((LEFT + 85) * mm, (TOP - i) * mm, u'%s %s' % (locale.format_string("%i", item.count, grouping=True), item.unit))
                 else:
-                    self.pdf.drawRightString((LEFT + 85) * mm, (TOP - i) * mm, u'%s %s' % (locale.format("%.2f", item.count, grouping=True), item.unit))
+                    self.pdf.drawRightString((LEFT + 85) * mm, (TOP - i) * mm, u'%s %s' % (locale.format_string("%.2f", item.count, grouping=True), item.unit))
                 self.pdf.drawRightString((LEFT + 110) * mm, (TOP - i) * mm, currency(item.price, self.invoice.currency, self.invoice.currency_locale))
                 self.pdf.drawRightString((LEFT + 134) * mm, (TOP - i) * mm, currency(item.total, self.invoice.currency, self.invoice.currency_locale))
                 self.pdf.drawRightString((LEFT + 144) * mm, (TOP - i) * mm, '%.0f %%' % item.tax)
@@ -371,9 +371,9 @@ class SimpleInvoice(BaseInvoice):
                 i += 5
             else:
                 if float(int(item.count)) == item.count:
-                    self.pdf.drawRightString((LEFT + 118) * mm, (TOP - i) * mm, u'%s %s' % (locale.format("%i", item.count, grouping=True), item.unit))
+                    self.pdf.drawRightString((LEFT + 118) * mm, (TOP - i) * mm, u'%s %s' % (locale.format_string("%i", item.count, grouping=True), item.unit))
                 else:
-                    self.pdf.drawRightString((LEFT + 118) * mm, (TOP - i) * mm, u'%s %s' % (locale.format("%.2f", item.count, grouping=True), item.unit))
+                    self.pdf.drawRightString((LEFT + 118) * mm, (TOP - i) * mm, u'%s %s' % (locale.format_string("%.2f", item.count, grouping=True), item.unit))
                 self.pdf.drawRightString((LEFT + 148) * mm, (TOP - i) * mm, currency(item.price, self.invoice.currency, self.invoice.currency_locale))
                 self.pdf.drawRightString((LEFT + 173) * mm, (TOP - i) * mm, currency(item.total, self.invoice.currency, self.invoice.currency_locale))
                 i += 5
@@ -409,7 +409,7 @@ class SimpleInvoice(BaseInvoice):
             self.pdf.drawString((LEFT + 1) * mm, (TOP - i - 2) * mm, _(u'Breakdown VAT'))
             vat_list, tax_list, total_list, total_tax_list = [_(u'VAT rate')], [_(u'Tax')], [_(u'Without VAT')], [_(u'With VAT')]
             for vat, items in self.invoice.generate_breakdown_vat().items():
-                vat_list.append("%s%%" % locale.format('%.2f', vat))
+                vat_list.append("%s%%" % locale.format_string('%.2f', vat))
                 tax_list.append(currency(items['tax'], self.invoice.currency, self.invoice.currency_locale))
                 total_list.append(currency(items['total'], self.invoice.currency, self.invoice.currency_locale))
                 total_tax_list.append(currency(items['total_tax'], self.invoice.currency, self.invoice.currency_locale))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,7 +37,7 @@ class AddressTest(unittest.TestCase):
         address_object = self.addresss_object(summary, address, city, zip_code)
 
         expected = [summary, address, u'%s %s' % (zip_code, city)]
-        self.assertEquals(expected, address_object._get_address_lines())
+        self.assertEqual(expected, address_object._get_address_lines())
 
     def test_get_contact_lines(self):
         phone = '56846846'
@@ -46,7 +46,7 @@ class AddressTest(unittest.TestCase):
         address = self.addresss_object('Foo s.r.o.', phone=phone, email=email)
 
         expected = [phone, email]
-        self.assertEquals(expected, address._get_contact_lines())
+        self.assertEqual(expected, address._get_contact_lines())
 
 
 class ClientTest(AddressTest):
@@ -107,23 +107,23 @@ class ItemTest(unittest.TestCase):
 
     def test_count_total(self):
         item = Item(42, 666, tax=21)
-        self.assertEquals(27972, item.total)
-        self.assertEquals(Decimal('33846.12'), item.total_tax)
+        self.assertEqual(27972, item.total)
+        self.assertEqual(Decimal('33846.12'), item.total_tax)
 
     def test_count_total_strings(self):
         item = Item('42', '666', tax='21')
-        self.assertEquals(27972, item.total)
-        self.assertEquals(Decimal('33846.12'), item.total_tax)
+        self.assertEqual(27972, item.total)
+        self.assertEqual(Decimal('33846.12'), item.total_tax)
 
     def test_count_total_decimal(self):
         item = Item(Decimal(42), Decimal(666), tax=Decimal(21))
-        self.assertEquals(27972, item.total)
-        self.assertEquals(Decimal('33846.12'), item.total_tax)
+        self.assertEqual(27972, item.total)
+        self.assertEqual(Decimal('33846.12'), item.total_tax)
 
     def test_count_total_float(self):
         item = Item(42.0, 666.0, tax=21.0)
-        self.assertEquals(27972, item.total)
-        self.assertEquals(Decimal('33846.12'), item.total_tax)
+        self.assertEqual(27972, item.total)
+        self.assertEqual(Decimal('33846.12'), item.total_tax)
 
     def test_count_tax(self):
 
@@ -138,7 +138,7 @@ class ItemTest(unittest.TestCase):
         price = 42
         tax = '99.9'
         item = Item(count, price, tax=tax)
-        self.assertEquals(Decimal('2014.992'), item.total_tax)
+        self.assertEqual(Decimal('2014.992'), item.total_tax)
 
     def test_count_total_with_none_tax(self):
         count = 24
@@ -146,12 +146,12 @@ class ItemTest(unittest.TestCase):
         tax = None
         item = Item(count, price, tax=tax)
         self.assertIsInstance(item.tax, Decimal)
-        self.assertEquals(1008, item.total_tax)
+        self.assertEqual(1008, item.total_tax)
 
     def test_count_total_with_zero_tax(self):
         item = Item(24, 42, tax=0)
         self.assertIsInstance(item.tax, Decimal)
-        self.assertEquals(1008, item.total_tax)
+        self.assertEqual(1008, item.total_tax)
 
 
 class InvoiceTest(unittest.TestCase):
@@ -186,7 +186,7 @@ class InvoiceTest(unittest.TestCase):
         for item in [Item(1, 500), Item(2, 500), Item(3, 500)]:
             invoice.add_item(item)
 
-        self.assertEquals(3, len(invoice.items))
+        self.assertEqual(3, len(invoice.items))
 
     def test_price(self):
         invoice = Invoice(Client('Foo'), Provider('Bar'), Creator('Blah'))
@@ -220,7 +220,7 @@ class InvoiceTest(unittest.TestCase):
             50.0: {'total': 2000.0, 'total_tax': 3000.0, 'tax': 1000},
         }
 
-        self.assertEquals(expected, invoice.generate_breakdown_vat())
+        self.assertEqual(expected, invoice.generate_breakdown_vat())
 
     def test_generate_breakdown_vat_table(self):
         invoice = Invoice(Client('Foo'), Provider('Bar'), Creator('Blah'))
@@ -231,13 +231,13 @@ class InvoiceTest(unittest.TestCase):
 
         expected = [(50.0, 2000.0, 3000.0, 1000.0), (0.00, 5000.0, 5000.0, 0)]
 
-        self.assertEquals(expected, invoice.generate_breakdown_vat_table())
+        self.assertEqual(expected, invoice.generate_breakdown_vat_table())
 
     def test_difference_rounding(self):
         invoice = Invoice(Client('Foo'), Provider('Bar'), Creator('Blah'))
         invoice.add_item(Item(1, 2.5, tax=50))
 
-        self.assertEquals(0.25, invoice.difference_in_rounding)
+        self.assertEqual(0.25, invoice.difference_in_rounding)
 
     def test_price_tax_rounding(self):
         """


### PR DESCRIPTION
`python -m pytest` produced deprecation warnings concerning the use of the `.format()` and `.assertEquals()` methods. This PR replaces them with the suggested upgrades.   

The results of the test suite after this change are below.   

```(venv) seanm @ ~/github/InvoiceGenerator>python -m pytest
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.9.2, pytest-7.1.1, pluggy-1.0.0
rootdir: /home/seanm/github/InvoiceGenerator
collected 42 items

tests/test_api.py ..................................                                                                                                                                                      [ 80%]
tests/test_generator.py ..                                                                                                                                                                                [ 85%]
tests/test_pdf.py ....                                                                                                                                                                                    [ 95%]
tests/test_pohoda.py ..                                                                                                                                                                                   [100%]

=============================================================================================== warnings summary ================================================================================================
InvoiceGenerator/conf.py:13: 1 warning
tests/test_generator.py: 12 warnings
tests/test_pdf.py: 100 warnings
  /home/seanm/github/InvoiceGenerator/InvoiceGenerator/conf.py:13: DeprecationWarning: parameter codeset is deprecated
    t = gettext.translation(

tests/test_generator.py::TestGenerator::test_gen
tests/test_pdf.py::TestBaseInvoice::test_generate
tests/test_pdf.py::TestBaseInvoice::test_generate
tests/test_pdf.py::TestBaseInvoice::test_generate_proforma
tests/test_pdf.py::TestBaseInvoice::test_generate_with_vat
  /home/seanm/github/InvoiceGenerator/InvoiceGenerator/pdf.py:105: DeprecationWarning: currency attribute is deprecated, use currency_locale instead
    warnings.warn("currency attribute is deprecated, use currency_locale instead", DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================= 42 passed, 118 warnings in 0.51s ========================================================================================```