### PR TITLE
Ensure proper cleanup of opened files and images

### DIFF
--- a/InvoiceGenerator/generator.py
+++ b/InvoiceGenerator/generator.py
@@ -127,9 +127,8 @@ class Invoice:
         self.pdf.showPage()
         self.pdf.save()
 
-        f = open(self.pdffile.name)
-        data = f.read()
-        f.close()
+        with open(self.pdffile.name) as f:
+            data = f.read()
 
         os.unlink(self.pdffile.name)
 
@@ -351,6 +350,5 @@ if __name__ == "__main__":
     invoice.addItem(item1)
     invoice.addItem(item2)
 
-    f = open("test.pdf", "w")
-    f.write(invoice.getContent())
-    f.close()
+    with open("test.pdf", "w") as f:
+        f.write(invoice.getContent())

--- a/InvoiceGenerator/pdf.py
+++ b/InvoiceGenerator/pdf.py
@@ -227,10 +227,10 @@ class SimpleInvoice(BaseInvoice):
         frame.addFromList([story_inframe], self.pdf)
 
         if address.logo_filename:
-            im = Image.open(address.logo_filename)
-            height = 30.0
-            width = float(im.size[0]) / (float(im.size[1])/height)
-            self.pdf.drawImage(self.invoice.provider.logo_filename, (left + 84) * mm - width, (top - 4) * mm, width, height, mask="auto")
+            with Image.open(address.logo_filename) as im:
+                height = 30.0
+                width = float(im.size[0]) / (float(im.size[1])/height)
+                self.pdf.drawImage(self.invoice.provider.logo_filename, (left + 84) * mm - width, (top - 4) * mm, width, height, mask="auto")
 
     def _drawClient(self, TOP, LEFT):
         self._drawAddress(TOP, LEFT, 88, 41, _(u'Customer'), self.invoice.client)
@@ -454,9 +454,9 @@ class SimpleInvoice(BaseInvoice):
     def _drawCreator(self, TOP, LEFT):
         height = 20*mm
         if self.invoice.creator.stamp_filename:
-            im = Image.open(self.invoice.creator.stamp_filename)
-            height = float(im.size[1]) / (float(im.size[0])/200.0)
-            self.pdf.drawImage(self.invoice.creator.stamp_filename, (LEFT) * mm, (TOP - 2) * mm - height, 200, height, mask="auto")
+            with Image.open(self.invoice.creator.stamp_filename) as im:
+                height = float(im.size[1]) / (float(im.size[0])/200.0)
+                self.pdf.drawImage(self.invoice.creator.stamp_filename, (LEFT) * mm, (TOP - 2) * mm - height, 200, height, mask="auto")
 
         path = self.pdf.beginPath()
         path.moveTo((LEFT + 8) * mm, (TOP) * mm - height)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ if sys.argv[-1] == "publish":
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
+        return f.read()
 
 
 description = ""


### PR DESCRIPTION
This PR fixes several cases where files and images were opened without being explicitly closed.

Previously, some code paths did not close files and images explicitly, which could leave file descriptors open in long-running processes or batch workflows. This change ensures proper resource management by using context managers to handle file closure.

Code that previously used manual file closing (`close()`) has also been updated to use context managers for consistency.

The issue was identified during an ongoing research project.